### PR TITLE
Check if first item in hapticActuators array exists

### DIFF
--- a/VRController.js
+++ b/VRController.js
@@ -320,7 +320,8 @@ THREE.VRController.onGamepadConnect = function( gamepad ){
 	//  Let’s give the controller a little rumble; some haptic feedback to 
 	//  let the user know it’s connected and happy.
 
-	if( controller.gamepad.hapticActuators ) controller.gamepad.hapticActuators[ 0 ].pulse( 0.1, 300 );
+	var hapticActuators = controller.gamepad.hapticActuators;
+	if( hapticActuators && hapticActuators[ 0 ] ) hapticActuators[ 0 ].pulse( 0.1, 300 );
 
 
 	//  Now we’ll broadcast a global connection event.


### PR DESCRIPTION
With the Oculus Touch controllers, `hapticActuators`  is an empty array, so there was an error in the console.