### PR TITLE
An unhandled exception may occur when expected buttons mismatch the actually reported ones

### DIFF
--- a/VRController.js
+++ b/VRController.js
@@ -170,16 +170,22 @@ THREE.VRController = function( gamepad ){
 		this.style = supported.style
 		if( supported.axes !== undefined ){
 
-			supported.axes.forEach( function( axesMap ){
+			supported.axes.forEach( function( axesMap, i ){
 
-				axes.byName[ axesMap.name ] = axesMap.indexes
+				if ( i < axes.length ){
+
+					axes.byName[ axesMap.name ] = axesMap.indexes
+				}
 			})
 		}
 		if( supported.buttons !== undefined ){
 
 			supported.buttons.forEach( function( buttonName, i ){
 
-				buttons[ i ].name = buttonName
+				if ( i < buttons.length ){
+
+					buttons[ i ].name = buttonName
+				}
 			})
 		}
 		buttonNamePrimary = supported.primary


### PR DESCRIPTION
Just recently hit that issue: different browsers may report different number of buttons (and theoretically - axes) for the same controllers (even though the order of those, obviously, must be correct). If the number of expected buttons is greater than the number of buttons actually reported then VRController throws an exception (in line 187).
For safety reasons I am adding if check for buttons and axes.